### PR TITLE
FEAT : MAIN PAGE & REVIEW PAGE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,12 @@ dependencies {
 	// JSON
 	implementation 'org.json:json:20231013'
 
+	// WEBJARS BOWER
+	// JQUERY
+	compileOnly 'org.webjars:jquery:3.5.1'
+	// BOOTSTRAP
+	compileOnly 'org.webjars:bootstrap:5.0.0'
+
 
 	// TEST IMPLEMENTATION ========================
 	// TEST DATABASE H2

--- a/src/main/java/com/ssg/starroadadmin/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/ssg/starroadadmin/global/config/WebSecurityConfig.java
@@ -1,34 +1,34 @@
-//package com.ssg.starroadadmin.global.config;
-//
-//import com.ssg.starroadadmin.user.service.impl.ManagerDetailsServiceImpl;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.context.annotation.Bean;
-//import org.springframework.context.annotation.Configuration;
-//import org.springframework.security.authentication.AuthenticationManager;
-//import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-//import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-//import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-//import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-//import org.springframework.security.web.SecurityFilterChain;
-//import org.springframework.web.bind.annotation.RequestMapping;
-//
-//import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
-//
-//@RequestMapping("/**")
-//@RequiredArgsConstructor
-//@Configuration
-//public class WebSecurityConfig {
-//
-//    private final ManagerDetailsServiceImpl managerDetailsService;
-//
-//    @Bean
-//    public WebSecurityCustomizer configure() {
-//        return (web) -> web.ignoring()
-//                .requestMatchers("/css/**", "/js/**", "/img/**", "/lib/**");
-//    }
-//
-//    @Bean
-//    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+package com.ssg.starroadadmin.global.config;
+
+import com.ssg.starroadadmin.user.service.impl.ManagerDetailsServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
+
+@RequestMapping("/**")
+@RequiredArgsConstructor
+@Configuration
+public class WebSecurityConfig {
+
+    private final ManagerDetailsServiceImpl managerDetailsService;
+
+    @Bean
+    public WebSecurityCustomizer configure() {
+        return (web) -> web.ignoring()
+                .requestMatchers("/css/**", "/js/**", "/img/**", "/lib/**");
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 //        return http
 //                .authorizeRequests()
 //                .requestMatchers("/login", "/signup", "/user").permitAll()
@@ -41,27 +41,31 @@
 //                .logout()
 //                .logoutSuccessUrl("/login")
 //                .invalidateHttpSession(true)
-
+//
 //                .and()
 //                .csrf().disable()
 //                .build();
-//    }
-//
-//    @Bean
-//    public AuthenticationManager authenticationManager(
-//            HttpSecurity http,
-//            BCryptPasswordEncoder bCryptPasswordEncoder
-//    ) throws Exception {
-//        return http.getSharedObject(AuthenticationManagerBuilder.class)
-//                .userDetailsService(managerDetailsService)
-//                .passwordEncoder(bCryptPasswordEncoder)
-//                .and()
-//                .build();
-//    }
-//
-//    @Bean
-//    public BCryptPasswordEncoder bCryptPasswordEncoder() {
-//        return new BCryptPasswordEncoder();
-//    }
-//
-//}
+        return http.authorizeRequests().anyRequest().permitAll()
+                .and()
+                .csrf(csrf -> csrf.disable())
+                .build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            HttpSecurity http,
+            BCryptPasswordEncoder bCryptPasswordEncoder
+    ) throws Exception {
+        return http.getSharedObject(AuthenticationManagerBuilder.class)
+                .userDetailsService(managerDetailsService)
+                .passwordEncoder(bCryptPasswordEncoder)
+                .and()
+                .build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/ssg/starroadadmin/global/error/code/FollowErrorCode.java
+++ b/src/main/java/com/ssg/starroadadmin/global/error/code/FollowErrorCode.java
@@ -1,0 +1,13 @@
+package com.ssg.starroadadmin.global.error.code;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum FollowErrorCode {
+    FOLLOW_LIST_NOT_FOUND("팔로우 리스트가 존재하지 않습니다.");
+
+    private final String description;
+}

--- a/src/main/java/com/ssg/starroadadmin/global/error/code/ReviewErrorCode.java
+++ b/src/main/java/com/ssg/starroadadmin/global/error/code/ReviewErrorCode.java
@@ -22,6 +22,10 @@ public enum ReviewErrorCode {
     REVIEW_NOT_WRITTEN_BY_USER_OR_ALREADY_DELETED("해당 리뷰는 사용자가 작성한 리뷰가 아니거나 이미 삭제된 리뷰입니다."),
     REVIEW_NOT_WRITTEN_BY_ADMIN_OR_ALREADY_DELETED("해당 리뷰는 관리자가 작성한 리뷰가 아니거나 이미 삭제된 리뷰입니다."),
     REVIEW_NOT_WRITTEN_BY_USER_OR_ADMIN_OR_NOT_FOUND_OR_ALREADY_DELETED("해당 리뷰는 사용자 또는 관리자가 작성한 리뷰가 아니거나 존재하지 않거나 이미 삭제된 리뷰입니다."),
-    REVIEW_NOT_WRITTEN_BY_USER_OR_NOT_FOUND_OR_ALREADY_DELETED("해당 리뷰는 사용자가 작성한 리뷰가 아니거나 존재하지 않거나 이미 삭제된 리뷰입니다.");
+    REVIEW_NOT_WRITTEN_BY_USER_OR_NOT_FOUND_OR_ALREADY_DELETED("해당 리뷰는 사용자가 작성한 리뷰가 아니거나 존재하지 않거나 이미 삭제된 리뷰입니다."),
+    ACCESS_DENIED("해당 리뷰에 접근할 권한이 없습니다."),
+    REVIEW_IMAGE_NOT_FOUND("해당 리뷰 이미지는 존재하지 않습니다."),
+    REVIEW_FEEDBACK_NOT_FOUND("해당 리뷰 피드백은 존재하지 않습니다."),
+    REVIEW_SENTIMENT_NOT_FOUND("해당 리뷰 감정분석은 존재하지 않습니다.");
     private final String description;
 }

--- a/src/main/java/com/ssg/starroadadmin/global/error/exception/FollowException.java
+++ b/src/main/java/com/ssg/starroadadmin/global/error/exception/FollowException.java
@@ -1,13 +1,13 @@
 package com.ssg.starroadadmin.global.error.exception;
 
+import com.ssg.starroadadmin.global.error.code.FollowErrorCode;
 import com.ssg.starroadadmin.global.error.code.ManagerErrorCode;
-import com.ssg.starroadadmin.global.error.code.ShopErrorCode;
 
-public class ManagerException extends RuntimeException {
-    private final ManagerErrorCode errorCode;
+public class FollowException  extends RuntimeException {
+    private final FollowErrorCode errorCode;
     private final String errorMessage;
 
-    public ManagerException(ManagerErrorCode errorCode) {
+    public FollowException(FollowErrorCode errorCode) {
         super(errorCode.getDescription());
         this.errorCode = errorCode;
         this.errorMessage = errorCode.getDescription();

--- a/src/main/java/com/ssg/starroadadmin/review/controller/ChartController.java
+++ b/src/main/java/com/ssg/starroadadmin/review/controller/ChartController.java
@@ -1,0 +1,43 @@
+package com.ssg.starroadadmin.review.controller;
+
+import com.ssg.starroadadmin.review.dto.MallReviewCountResponse;
+import com.ssg.starroadadmin.review.dto.StoreReviewCountResponse;
+import com.ssg.starroadadmin.review.service.ChartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/chart")
+@RequiredArgsConstructor
+public class ChartController {
+    private final ChartService chartService;
+
+
+
+    @GetMapping("/mall/review-count")
+    public ResponseEntity<List<MallReviewCountResponse>> getMallReviewCountChart(
+            // jwt로 받아온 관리자 ID
+    ) {
+        Long mallManagerId = 5L; // 삭제해야할 부분
+
+        List<MallReviewCountResponse> reviewChartResponses = chartService.gerMallReviewCount(mallManagerId);
+
+        return ResponseEntity.ok(reviewChartResponses);
+    }
+
+    @GetMapping("/store/review-count")
+    public ResponseEntity<List<StoreReviewCountResponse>> getStoreReviewCountChart(
+            // jwt로 받아온 관리자 ID
+    ) {
+        Long mallManagerId = 5L; // 삭제해야할 부분
+
+        List<StoreReviewCountResponse> reviewChartResponses = chartService.gerStoreReviewCount(mallManagerId);
+
+        return ResponseEntity.ok(reviewChartResponses);
+    }
+}

--- a/src/main/java/com/ssg/starroadadmin/review/dto/ExcludedReviewList.java
+++ b/src/main/java/com/ssg/starroadadmin/review/dto/ExcludedReviewList.java
@@ -1,0 +1,16 @@
+package com.ssg.starroadadmin.review.dto;
+
+import com.ssg.starroadadmin.review.entity.ReviewFeedback;
+import com.ssg.starroadadmin.review.entity.ReviewImage;
+import com.ssg.starroadadmin.review.entity.ReviewSentiment;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ExcludedReviewList(
+        List<ReviewImage> reviewImages,
+        List<ReviewFeedback> reviewFeedbacks,
+        List<ReviewSentiment> reviewSentimentResponses
+) {
+}

--- a/src/main/java/com/ssg/starroadadmin/review/dto/MallReviewCountResponse.java
+++ b/src/main/java/com/ssg/starroadadmin/review/dto/MallReviewCountResponse.java
@@ -1,0 +1,11 @@
+package com.ssg.starroadadmin.review.dto;
+
+public record MallReviewCountResponse(
+        Long reviewCount,
+        int reviewYear,
+        int reviewMonth,
+        Long positiveReviewCount,
+        Long neutralReviewCount,
+        Long negativeReviewCount
+) {
+}

--- a/src/main/java/com/ssg/starroadadmin/review/dto/PopularStore.java
+++ b/src/main/java/com/ssg/starroadadmin/review/dto/PopularStore.java
@@ -1,0 +1,17 @@
+package com.ssg.starroadadmin.review.dto;
+
+import com.ssg.starroadadmin.shop.enums.Floor;
+
+public record PopularStore(
+        Long storeId,
+        String storeName,
+        String storeImage,
+        Long mallId,
+        String mallName,
+        Floor floor,
+        Long reviewCount,
+        Long positiveReviewCount,
+        Long neutralReviewCount,
+        Long negativeReviewCount
+) {
+}

--- a/src/main/java/com/ssg/starroadadmin/review/dto/PopularStoreResponse.java
+++ b/src/main/java/com/ssg/starroadadmin/review/dto/PopularStoreResponse.java
@@ -1,0 +1,17 @@
+package com.ssg.starroadadmin.review.dto;
+
+import com.ssg.starroadadmin.shop.enums.Floor;
+
+public record PopularStoreResponse(
+        Long storeId,
+        String storeName,
+        String storeImage,
+        Long mallId,
+        String mallName,
+        String floor,
+        Long reviewCount,
+        Long positiveReviewCount,
+        Long neutralReviewCount,
+        Long negativeReviewCount
+) {
+}

--- a/src/main/java/com/ssg/starroadadmin/review/dto/RecentReviewResponse.java
+++ b/src/main/java/com/ssg/starroadadmin/review/dto/RecentReviewResponse.java
@@ -1,0 +1,14 @@
+package com.ssg.starroadadmin.review.dto;
+
+import lombok.Builder;
+
+@Builder
+public record RecentReviewResponse(
+        Long reviewId,
+        String userName,
+        String userImagePath,
+        Long followerCount,
+        Long followingCount,
+        String contents
+) {
+}

--- a/src/main/java/com/ssg/starroadadmin/review/dto/ReviewAnswerResponse.java
+++ b/src/main/java/com/ssg/starroadadmin/review/dto/ReviewAnswerResponse.java
@@ -1,0 +1,15 @@
+package com.ssg.starroadadmin.review.dto;
+
+public record ReviewAnswerResponse(
+        // 리뷰 댓글
+        Long reviewAnswerId,
+        String contents,
+
+        // 유저
+        Long userId,
+        String nickname,
+
+        // 리뷰
+        Long reviewId
+) {
+}

--- a/src/main/java/com/ssg/starroadadmin/review/dto/ReviewDetailResponse.java
+++ b/src/main/java/com/ssg/starroadadmin/review/dto/ReviewDetailResponse.java
@@ -1,0 +1,72 @@
+package com.ssg.starroadadmin.review.dto;
+
+import com.ssg.starroadadmin.review.entity.ReviewFeedback;
+import com.ssg.starroadadmin.review.entity.ReviewImage;
+import com.ssg.starroadadmin.review.enums.ConfidenceType;
+import com.ssg.starroadadmin.shop.enums.Floor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ReviewDetailResponse(
+        // 쇼핑몰
+        Long mallId,
+        String mallName,
+
+        // 매장
+        Long storeId,
+        String storeName,
+        Floor floor,
+        String storeImagePath,
+
+        // 유저
+        Long userId,
+        String userName,
+        String nickname,
+        String userImagePath,
+
+        // 리뷰
+        Long reviewId,
+        boolean visible,
+        int likeCount,
+        String contents,
+        ConfidenceType confidence,
+        String summary,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
+
+        // 리뷰 이미지들
+        List<String> reviewImagePaths,
+
+        // 리뷰 선택지들
+        List<String> reviewFeedbackSelection,
+
+        // 리뷰 sentiment
+        List<ReviewSentimentResponse> reviewSentimentResponses
+) {
+    public static ReviewDetailResponse from(ReviewDetailWithOutList reviewDetailWithOutList, ExcludedReviewList excludedList) {
+        return new ReviewDetailResponse(
+                reviewDetailWithOutList.mallId(),
+                reviewDetailWithOutList.mallName(),
+                reviewDetailWithOutList.storeId(),
+                reviewDetailWithOutList.storeName(),
+                reviewDetailWithOutList.floor(),
+                reviewDetailWithOutList.storeImagePath(),
+                reviewDetailWithOutList.userId(),
+                reviewDetailWithOutList.userName(),
+                reviewDetailWithOutList.nickname(),
+                reviewDetailWithOutList.userImagePath(),
+                reviewDetailWithOutList.reviewId(),
+                reviewDetailWithOutList.visible(),
+                reviewDetailWithOutList.likeCount(),
+                reviewDetailWithOutList.contents(),
+                reviewDetailWithOutList.confidence(),
+                reviewDetailWithOutList.summary(),
+                reviewDetailWithOutList.createdAt(),
+                reviewDetailWithOutList.modifiedAt(),
+                excludedList.reviewImages().stream().map(ReviewImage::getImagePath).toList(),
+                excludedList.reviewFeedbacks().stream().map(ReviewFeedback::getReviewFeedbackSelection).toList(),
+                excludedList.reviewSentimentResponses().stream().map(ReviewSentimentResponse::from).toList()
+        );
+    }
+}

--- a/src/main/java/com/ssg/starroadadmin/review/dto/ReviewDetailWithOutList.java
+++ b/src/main/java/com/ssg/starroadadmin/review/dto/ReviewDetailWithOutList.java
@@ -1,0 +1,35 @@
+package com.ssg.starroadadmin.review.dto;
+
+import com.ssg.starroadadmin.review.enums.ConfidenceType;
+import com.ssg.starroadadmin.shop.enums.Floor;
+
+import java.time.LocalDateTime;
+
+public record ReviewDetailWithOutList(
+        // 쇼핑몰
+        Long mallId,
+        String mallName,
+
+        // 매장
+        Long storeId,
+        String storeName,
+        Floor floor,
+        String storeImagePath,
+
+        // 유저
+        Long userId,
+        String userName,
+        String nickname,
+        String userImagePath,
+
+        // 리뷰
+        Long reviewId,
+        boolean visible,
+        int likeCount,
+        String contents,
+        ConfidenceType confidence,
+        String summary,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+}

--- a/src/main/java/com/ssg/starroadadmin/review/dto/ReviewSentimentResponse.java
+++ b/src/main/java/com/ssg/starroadadmin/review/dto/ReviewSentimentResponse.java
@@ -1,0 +1,26 @@
+package com.ssg.starroadadmin.review.dto;
+
+import com.ssg.starroadadmin.review.entity.ReviewSentiment;
+import com.ssg.starroadadmin.review.enums.ConfidenceType;
+
+public record ReviewSentimentResponse(
+        Long id,
+        Long reviewId,
+        ConfidenceType confidence,
+        int length,
+        int offset,
+        int highlightLength,
+        int highlightOffset
+) {
+    public static ReviewSentimentResponse from(ReviewSentiment reviewSentiment) {
+        return new ReviewSentimentResponse(
+                reviewSentiment.getId(),
+                reviewSentiment.getReview().getId(),
+                reviewSentiment.getConfidence(),
+                reviewSentiment.getTotalLength(),
+                reviewSentiment.getTotalOffset(),
+                reviewSentiment.getHighlightLength(),
+                reviewSentiment.getHighlightOffset()
+        );
+    }
+}

--- a/src/main/java/com/ssg/starroadadmin/review/dto/StoreReviewCountResponse.java
+++ b/src/main/java/com/ssg/starroadadmin/review/dto/StoreReviewCountResponse.java
@@ -1,0 +1,10 @@
+package com.ssg.starroadadmin.review.dto;
+
+public record StoreReviewCountResponse(
+        String storeName,
+        Long totalReviewCount,
+        Long positiveReviewCount,
+        Long neutralReviewCount,
+        Long negativeReviewCount
+) {
+}

--- a/src/main/java/com/ssg/starroadadmin/review/repository/ChartRepositoryCustom.java
+++ b/src/main/java/com/ssg/starroadadmin/review/repository/ChartRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.ssg.starroadadmin.review.repository;
+
+import com.ssg.starroadadmin.review.dto.MallReviewCountResponse;
+import com.ssg.starroadadmin.review.dto.StoreReviewCountResponse;
+import com.ssg.starroadadmin.user.entity.Manager;
+
+import java.util.List;
+
+public interface ChartRepositoryCustom {
+    List<MallReviewCountResponse> findMallReviewsByManager(Manager manager);
+
+    List<StoreReviewCountResponse> findStoreReviewsByManager(Manager manager);
+}

--- a/src/main/java/com/ssg/starroadadmin/review/repository/ReviewFeedbackRepository.java
+++ b/src/main/java/com/ssg/starroadadmin/review/repository/ReviewFeedbackRepository.java
@@ -1,0 +1,11 @@
+package com.ssg.starroadadmin.review.repository;
+
+import com.ssg.starroadadmin.review.entity.ReviewFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReviewFeedbackRepository extends JpaRepository<ReviewFeedback, Long> {
+    Optional<List<ReviewFeedback>> findAllByReviewId(Long reviewId);
+}

--- a/src/main/java/com/ssg/starroadadmin/review/repository/ReviewImageRepository.java
+++ b/src/main/java/com/ssg/starroadadmin/review/repository/ReviewImageRepository.java
@@ -1,0 +1,11 @@
+package com.ssg.starroadadmin.review.repository;
+
+import com.ssg.starroadadmin.review.entity.ReviewImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+    Optional<List<ReviewImage>> findAllByReviewId(Long reviewId);
+}

--- a/src/main/java/com/ssg/starroadadmin/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ssg/starroadadmin/review/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.ssg.starroadadmin.review.repository;
 
+import com.ssg.starroadadmin.review.dto.RecentReviewResponse;
 import com.ssg.starroadadmin.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Optional<List<Review>> findAllByStoreId(Long storeId);
 
     Long countByUserId(Long id);
+
+    Optional<List<Review>> findTop5ByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/ssg/starroadadmin/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/ssg/starroadadmin/review/repository/ReviewRepositoryCustom.java
@@ -1,13 +1,24 @@
 package com.ssg.starroadadmin.review.repository;
 
 import com.ssg.starroadadmin.global.dto.BetweenDate;
+import com.ssg.starroadadmin.review.dto.PopularStore;
+import com.ssg.starroadadmin.review.dto.ReviewDetailWithOutList;
 import com.ssg.starroadadmin.review.dto.ReviewListResponse;
 import com.ssg.starroadadmin.review.enums.ReviewSortType;
+import com.ssg.starroadadmin.user.entity.Manager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface ReviewRepositoryCustom {
+
     Page<ReviewListResponse> findAllByStoreIdAndBetweenDate(Long storeId, BetweenDate betweenDate, ReviewSortType reviewSortType, Pageable pageable);
 
     Page<ReviewListResponse> findAllByUserIdAndBetweenDate(Long userId, BetweenDate betweenDate, ReviewSortType reviewSortType, Pageable pageable);
+
+    ReviewDetailWithOutList findAllByManager(Manager manager, Long reviewId);
+
+    Optional<List<PopularStore>> findTop5PopularStore();
 }

--- a/src/main/java/com/ssg/starroadadmin/review/repository/ReviewSentimentRepository.java
+++ b/src/main/java/com/ssg/starroadadmin/review/repository/ReviewSentimentRepository.java
@@ -1,0 +1,11 @@
+package com.ssg.starroadadmin.review.repository;
+
+import com.ssg.starroadadmin.review.entity.ReviewSentiment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReviewSentimentRepository extends JpaRepository<ReviewSentiment, Long> {
+    Optional<List<ReviewSentiment>> findAllByReviewId(Long reviewId);
+}

--- a/src/main/java/com/ssg/starroadadmin/review/repository/impl/ChartRepositoryCustomImpl.java
+++ b/src/main/java/com/ssg/starroadadmin/review/repository/impl/ChartRepositoryCustomImpl.java
@@ -1,0 +1,100 @@
+package com.ssg.starroadadmin.review.repository.impl;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ssg.starroadadmin.review.dto.MallReviewCountResponse;
+import com.ssg.starroadadmin.review.dto.StoreReviewCountResponse;
+import com.ssg.starroadadmin.review.enums.ConfidenceType;
+import com.ssg.starroadadmin.review.repository.ChartRepositoryCustom;
+import com.ssg.starroadadmin.user.entity.Manager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.querydsl.core.types.dsl.Expressions.FALSE;
+import static com.ssg.starroadadmin.review.entity.QReview.review;
+import static com.ssg.starroadadmin.review.enums.ConfidenceType.*;
+import static com.ssg.starroadadmin.shop.entity.QComplexShoppingmall.complexShoppingmall;
+import static com.ssg.starroadadmin.shop.entity.QStore.store;
+
+@Repository
+@RequiredArgsConstructor
+public class ChartRepositoryCustomImpl implements ChartRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public List<MallReviewCountResponse> findMallReviewsByManager(Manager manager) {
+        return queryFactory
+                .select(
+                        Projections.constructor(MallReviewCountResponse.class,
+                                review.count().as("reviewCount"),
+                                review.createdAt.year().as("reviewYear"),
+                                review.createdAt.month().as("reviewMonth"),
+                                review.confidence.nullif(POSITIVE).count().as("positiveReviewCount"),
+                                review.confidence.nullif(NEUTRAL).count().as("neutralReviewCount"),
+                                review.confidence.nullif(NEGATIVE).count().as("negativeReviewCount")
+                        ))
+                .from(review)
+                .innerJoin(store).on(review.store.id.eq(store.id))
+                .innerJoin(complexShoppingmall).on(store.complexShoppingmall.id.eq(complexShoppingmall.id)
+                )
+                .where(
+                        managerEq(manager),
+                        // 오늘 날짜 기준 1년 전까지의 데이터만 조회
+                        review.createdAt.after(LocalDateTime.now().minusYears(1))
+                )
+                .groupBy(
+                        review.createdAt.year(),
+                        review.createdAt.month()
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<StoreReviewCountResponse> findStoreReviewsByManager(Manager manager) {
+        return queryFactory
+                .select(
+                        Projections.constructor(StoreReviewCountResponse.class,
+                                store.name.as("storeName"),
+                                review.count().as("reviewCount"),
+                                ConfidenceCount(POSITIVE).as("positiveReviewCount"),
+                                ConfidenceCount(NEUTRAL).as("neutralReviewCount"),
+                                ConfidenceCount(NEGATIVE).as("negativeReviewCount")
+                        ))
+                .from(review)
+                .innerJoin(store).on(review.store.id.eq(store.id))
+                .innerJoin(complexShoppingmall).on(store.complexShoppingmall.id.eq(complexShoppingmall.id)
+                )
+                .where(
+                        managerEq(manager),
+                        // 오늘 날짜 기준 3개월 전까지의 데이터만 조회
+                        review.createdAt.after(LocalDateTime.now().minusMonths(3))
+                )
+                .groupBy(
+                        store.name
+                )
+                .fetch();
+    }
+
+    private NumberExpression<Long> ConfidenceCount(ConfidenceType confidenceType) {
+        return review.confidence
+                .when(confidenceType).then(1L)
+                .otherwise(0L).sum();
+    }
+
+    private BooleanExpression managerEq(Manager manager) {
+        switch (manager.getAuthority()) {
+            case MALL:
+                return complexShoppingmall.manager.id.eq(manager.getId());
+            case STORE: // 매장 관리자에서 매장을 찾고 매창의 복합 쇼핑몰을 찾아서 복합 쇼핑몰의 pk와 쇼핑몰 pk가 같은지 확인
+                return complexShoppingmall.id.eq(store.complexShoppingmall.id).and(store.manager.id.eq(manager.getId()));
+            default:
+                return FALSE;
+        }
+    }
+}

--- a/src/main/java/com/ssg/starroadadmin/review/repository/impl/ReviewFeedbackRepositoryCustomImpl.java
+++ b/src/main/java/com/ssg/starroadadmin/review/repository/impl/ReviewFeedbackRepositoryCustomImpl.java
@@ -1,9 +1,8 @@
-package com.ssg.starroadadmin.review.repository;
+package com.ssg.starroadadmin.review.repository.impl;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.ssg.starroadadmin.review.entity.QReview;
-import com.ssg.starroadadmin.review.entity.QReviewFeedback;
+import com.ssg.starroadadmin.review.repository.ReviewFeedbackRepositoryCustom;
 import com.ssg.starroadadmin.shop.dto.StoreFeedbackResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/ssg/starroadadmin/review/service/ChartService.java
+++ b/src/main/java/com/ssg/starroadadmin/review/service/ChartService.java
@@ -1,0 +1,24 @@
+package com.ssg.starroadadmin.review.service;
+
+import com.ssg.starroadadmin.review.dto.MallReviewCountResponse;
+import com.ssg.starroadadmin.review.dto.StoreReviewCountResponse;
+
+import java.util.List;
+
+public interface ChartService {
+
+
+    /**
+     * 월별 리뷰 수 조회하여 차트 데이터로 반환
+     *
+     * @param mallManagerId
+     */
+    List<MallReviewCountResponse> gerMallReviewCount(Long mallManagerId);
+
+    /**
+     * 최근 3개월 매장별 리뷰 수 조회하여 차트 데이터로 반환
+     *
+     * @param mallManagerId
+     */
+    List<StoreReviewCountResponse> gerStoreReviewCount(Long mallManagerId);
+}

--- a/src/main/java/com/ssg/starroadadmin/review/service/ReviewService.java
+++ b/src/main/java/com/ssg/starroadadmin/review/service/ReviewService.java
@@ -1,11 +1,10 @@
 package com.ssg.starroadadmin.review.service;
 
-import com.ssg.starroadadmin.review.dto.ReviewListResponse;
-import com.ssg.starroadadmin.review.dto.ReviewListWithDasyAgoResponse;
-import com.ssg.starroadadmin.review.dto.StoreReviewSearchRequest;
-import com.ssg.starroadadmin.review.dto.UserReviewSearchRequest;
+import com.ssg.starroadadmin.review.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface ReviewService {
 
@@ -13,7 +12,7 @@ public interface ReviewService {
      * 매장별 리뷰 리스트 조회
      *
      * @param reviewSearchRequest
-     * @return
+     * @return Page<ReviewListWithDasyAgoResponse>
      */
     Page<ReviewListWithDasyAgoResponse> searchReviewList(Long managerId, StoreReviewSearchRequest reviewSearchRequest, Pageable pageable);
 
@@ -21,7 +20,30 @@ public interface ReviewService {
      * 사용자별 리뷰 리스트 조회
      *
      * @param reviewSearchRequest
-     * @return
+     * @return Page<ReviewListWithDasyAgoResponse>
      */
     Page<ReviewListWithDasyAgoResponse> searchReviewList(Long managerId, UserReviewSearchRequest reviewSearchRequest, Pageable pageable);
+
+    /**
+     * 리뷰 상세 조회
+     *
+     * @param mallManagerId
+     * @param reviewId
+     * @return ReviewDetailResponse
+     */
+    ReviewDetailResponse getReview(Long mallManagerId, Long reviewId);
+
+    /**
+     * 최근 리뷰 5개 조회
+     *
+     * @return List<RecentReviewResponse>
+     */
+    List<RecentReviewResponse> getRecentReviewList();
+
+    /**
+     * 인기 매장 조회
+     *
+     * @return List<PopularStoreResponse>
+     */
+    List<PopularStore> getPopularStoreList();
 }

--- a/src/main/java/com/ssg/starroadadmin/review/service/impl/ChartServiceImpl.java
+++ b/src/main/java/com/ssg/starroadadmin/review/service/impl/ChartServiceImpl.java
@@ -1,0 +1,49 @@
+package com.ssg.starroadadmin.review.service.impl;
+
+import com.ssg.starroadadmin.global.error.code.ManagerErrorCode;
+import com.ssg.starroadadmin.global.error.exception.ManagerException;
+import com.ssg.starroadadmin.review.dto.MallReviewCountResponse;
+import com.ssg.starroadadmin.review.dto.StoreReviewCountResponse;
+import com.ssg.starroadadmin.review.repository.ChartRepositoryCustom;
+import com.ssg.starroadadmin.review.service.ChartService;
+import com.ssg.starroadadmin.user.entity.Manager;
+import com.ssg.starroadadmin.user.repository.ManagerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChartServiceImpl implements ChartService {
+    private final ChartRepositoryCustom charRepository;
+    private final ManagerRepository managerRepository;
+
+
+    /**
+     * 월별 리뷰 수 조회하여 차트 데이터로 반환
+     *
+     * @param mallManagerId
+     */
+    public List<MallReviewCountResponse> gerMallReviewCount(Long mallManagerId) {
+        Manager manager = managerRepository.findById(mallManagerId)
+                .orElseThrow(() -> new ManagerException(ManagerErrorCode.MANAGER_NOT_FOUND));
+
+        List<MallReviewCountResponse> responseList = charRepository.findMallReviewsByManager(manager);
+
+        return responseList;
+    }
+
+    @Override
+    public List<StoreReviewCountResponse> gerStoreReviewCount(Long mallManagerId) {
+        Manager manager = managerRepository.findById(mallManagerId)
+                .orElseThrow(() -> new ManagerException(ManagerErrorCode.MANAGER_NOT_FOUND));
+
+        List<StoreReviewCountResponse> responseList = charRepository.findStoreReviewsByManager(manager);
+
+        log.debug("responseList: {}", responseList);
+        return responseList;
+    }
+}

--- a/src/main/java/com/ssg/starroadadmin/shop/controller/ComplexShoppingmallController.java
+++ b/src/main/java/com/ssg/starroadadmin/shop/controller/ComplexShoppingmallController.java
@@ -22,10 +22,8 @@ public class ComplexShoppingmallController {
     ) {
         Long managerId = 5L; // 삭제해야할 부분
 
-        System.out.println("managerId = " + managerId);
         String mallName = complexShoppingmallService.getComplexShoppingmallName(managerId);
 
-        System.out.println("mallName = "    + mallName);
         return mallName;
     }
 }

--- a/src/main/java/com/ssg/starroadadmin/shop/controller/StoreController.java
+++ b/src/main/java/com/ssg/starroadadmin/shop/controller/StoreController.java
@@ -72,7 +72,7 @@ public class StoreController {
         return "store/storeList";
     }
 
-    @GetMapping("/{storeId}")
+    @GetMapping("/detail/{storeId}")
     public String storeDetail(Model model
             // jwt로 받아온 관리자 ID
             , @PathVariable Long storeId) {

--- a/src/main/java/com/ssg/starroadadmin/user/controller/FollowController.java
+++ b/src/main/java/com/ssg/starroadadmin/user/controller/FollowController.java
@@ -1,0 +1,27 @@
+package com.ssg.starroadadmin.user.controller;
+
+import com.ssg.starroadadmin.user.dto.PopularUserResponse;
+import com.ssg.starroadadmin.user.service.FollowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/follow")
+@RequiredArgsConstructor
+public class FollowController {
+    private final FollowService followService;
+
+    @ResponseBody
+    @GetMapping("/user/popular")
+    public ResponseEntity<List<PopularUserResponse>> popularUserList() {
+        List<PopularUserResponse> popularUserList = followService.getPopularUserList();
+
+        return ResponseEntity.ok().body(popularUserList);
+    }
+}

--- a/src/main/java/com/ssg/starroadadmin/user/controller/UserController.java
+++ b/src/main/java/com/ssg/starroadadmin/user/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
         return "user/userList";
     }
 
-    @GetMapping("/{userId}")
+    @GetMapping("/detail/{userId}")
     public String userDetail(Model model,
                              // jwt로 받아온 관리자 ID
                              @PathVariable Long userId) {

--- a/src/main/java/com/ssg/starroadadmin/user/dto/PopularUserResponse.java
+++ b/src/main/java/com/ssg/starroadadmin/user/dto/PopularUserResponse.java
@@ -1,0 +1,11 @@
+package com.ssg.starroadadmin.user.dto;
+
+public record PopularUserResponse(
+    Long userId,
+    String userName,
+    String imagePath,
+    Long followerCount,
+    Long followingCount,
+    Long reviewCount
+) {
+}

--- a/src/main/java/com/ssg/starroadadmin/user/repository/FollowRepository.java
+++ b/src/main/java/com/ssg/starroadadmin/user/repository/FollowRepository.java
@@ -1,0 +1,29 @@
+package com.ssg.starroadadmin.user.repository;
+
+import com.ssg.starroadadmin.user.dto.PopularUserResponse;
+import com.ssg.starroadadmin.user.entity.Follow;
+import jakarta.persistence.TypedQuery;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    Long countByToUser_Id(Long id);
+
+    Long countByFromUser_Id(Long id);
+
+    @Query("SELECT new com.ssg.starroadadmin.user.dto.PopularUserResponse(" +
+            "u.id, " +
+            "u.name, " +
+            "u.imagePath, " +
+            "(SELECT COUNT(f.id) FROM Follow f WHERE f.toUser.id = u.id), " +
+            "(SELECT COUNT(f.id) FROM Follow f WHERE f.fromUser.id = u.id), " +
+            "(SELECT COUNT(r.id) FROM Review r WHERE r.user.id = u.id)) " +
+            "FROM User u " +
+            "ORDER BY (SELECT COUNT(f.id) FROM Follow f WHERE f.toUser.id = u.id) DESC")
+    List<PopularUserResponse> findTop5ByFollow();
+
+
+}

--- a/src/main/java/com/ssg/starroadadmin/user/repository/FollowRepositoryCustom.java
+++ b/src/main/java/com/ssg/starroadadmin/user/repository/FollowRepositoryCustom.java
@@ -1,0 +1,19 @@
+package com.ssg.starroadadmin.user.repository;
+
+import com.ssg.starroadadmin.user.dto.PopularUserResponse;
+import com.ssg.starroadadmin.user.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FollowRepositoryCustom {
+
+    /**
+     * 사용자별 팔로워 수, 팔로잉 수, 리뷰 수를 조회하여 인기 유저 리스트를 반환한다.
+     *
+     * @return 인기 유저 리스트
+     */
+    Optional<List<PopularUserResponse>> findTop5ByUser();
+}

--- a/src/main/java/com/ssg/starroadadmin/user/repository/impl/FollowRepositoryCustomImpl.java
+++ b/src/main/java/com/ssg/starroadadmin/user/repository/impl/FollowRepositoryCustomImpl.java
@@ -1,0 +1,48 @@
+package com.ssg.starroadadmin.user.repository.impl;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ssg.starroadadmin.review.entity.QReview;
+import com.ssg.starroadadmin.user.dto.PopularUserResponse;
+import com.ssg.starroadadmin.user.entity.QFollow;
+import com.ssg.starroadadmin.user.entity.User;
+import com.ssg.starroadadmin.user.repository.FollowRepositoryCustom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.ssg.starroadadmin.user.entity.QFollow.follow;
+import static com.ssg.starroadadmin.user.entity.QUser.user;
+
+@Repository
+@RequiredArgsConstructor
+public class FollowRepositoryCustomImpl implements FollowRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<List<PopularUserResponse>> findTop5ByUser() {
+        List<User> popularUser = queryFactory
+                .selectFrom(user)
+                .innerJoin(follow).on(follow.toUser.eq(user))
+                .orderBy(
+                        follow.toUser.count().desc()
+                )
+                .fetch();
+
+        return Optional.ofNullable(popularUser.stream().map(
+                user -> new PopularUserResponse(
+                        user.getId(),
+                        user.getName(),
+                        user.getImagePath(),
+                        queryFactory.selectFrom(follow).where(follow.toUser.eq(user)).fetchCount(),
+                        queryFactory.selectFrom(follow).where(follow.fromUser.eq(user)).fetchCount(),
+                        JPAExpressions.selectFrom(QReview.review).where(QReview.review.user.eq(user)).fetchCount()
+                )
+        )
+                .toList()
+        );
+    }
+}

--- a/src/main/java/com/ssg/starroadadmin/user/service/FollowService.java
+++ b/src/main/java/com/ssg/starroadadmin/user/service/FollowService.java
@@ -1,0 +1,9 @@
+package com.ssg.starroadadmin.user.service;
+
+import com.ssg.starroadadmin.user.dto.PopularUserResponse;
+
+import java.util.List;
+
+public interface FollowService {
+    List<PopularUserResponse> getPopularUserList();
+}

--- a/src/main/java/com/ssg/starroadadmin/user/service/impl/FollowServiceImpl.java
+++ b/src/main/java/com/ssg/starroadadmin/user/service/impl/FollowServiceImpl.java
@@ -1,0 +1,32 @@
+package com.ssg.starroadadmin.user.service.impl;
+
+import com.ssg.starroadadmin.global.error.code.FollowErrorCode;
+import com.ssg.starroadadmin.global.error.exception.FollowException;
+import com.ssg.starroadadmin.user.dto.PopularUserResponse;
+import com.ssg.starroadadmin.user.repository.FollowRepository;
+import com.ssg.starroadadmin.user.repository.FollowRepositoryCustom;
+import com.ssg.starroadadmin.user.service.FollowService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FollowServiceImpl implements FollowService {
+//    private final FollowRepositoryCustom followRepositoryCustom;
+    private final FollowRepository followRepository;
+
+    @Override
+    public List<PopularUserResponse> getPopularUserList() {
+        System.out.println("===========getPopularUserList()===========");
+        List<PopularUserResponse> top5ByUserList = followRepository.findTop5ByFollow();
+//        List<PopularUserResponse> top5ByUserList = followRepositoryCustom.findTop5ByUser()
+//                .orElseThrow(() -> new FollowException(FollowErrorCode.FOLLOW_LIST_NOT_FOUND));
+        System.out.println("===========getPopularUserList()===========");
+        log.info("top5ByUserList: {}", top5ByUserList);
+        return top5ByUserList;
+    }
+}

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -40,168 +40,168 @@
         });
     }, {offset: '80%'});
 
+    //
+    // // Calender
+    // $('#calender').datetimepicker({
+    //     inline: true,
+    //     format: 'L'
+    // });
 
-    // Calender
-    $('#calender').datetimepicker({
-        inline: true,
-        format: 'L'
-    });
+    //
+    // // Testimonials carousel
+    // $(".testimonial-carousel").owlCarousel({
+    //     autoplay: true,
+    //     smartSpeed: 1000,
+    //     items: 1,
+    //     dots: true,
+    //     loop: true,
+    //     nav : false
+    // });
 
-
-    // Testimonials carousel
-    $(".testimonial-carousel").owlCarousel({
-        autoplay: true,
-        smartSpeed: 1000,
-        items: 1,
-        dots: true,
-        loop: true,
-        nav : false
-    });
-
-
-    // Worldwide Sales Chart
-    var ctx1 = $("#worldwide-sales").get(0).getContext("2d");
-    var myChart1 = new Chart(ctx1, {
-        type: "bar",
-        data: {
-            labels: ["2016", "2017", "2018", "2019", "2020", "2021", "2022"],
-            datasets: [{
-                    label: "USA",
-                    data: [15, 30, 55, 65, 60, 80, 95],
-                    backgroundColor: "rgba(0, 156, 255, .7)"
-                },
-                {
-                    label: "UK",
-                    data: [8, 35, 40, 60, 70, 55, 75],
-                    backgroundColor: "rgba(0, 156, 255, .5)"
-                },
-                {
-                    label: "AU",
-                    data: [12, 25, 45, 55, 65, 70, 60],
-                    backgroundColor: "rgba(0, 156, 255, .3)"
-                }
-            ]
-            },
-        options: {
-            responsive: true
-        }
-    });
-
-
-    // Salse & Revenue Chart
-    var ctx2 = $("#salse-revenue").get(0).getContext("2d");
-    var myChart2 = new Chart(ctx2, {
-        type: "line",
-        data: {
-            labels: ["2016", "2017", "2018", "2019", "2020", "2021", "2022"],
-            datasets: [{
-                    label: "Salse",
-                    data: [15, 30, 55, 45, 70, 65, 85],
-                    backgroundColor: "rgba(0, 156, 255, .5)",
-                    fill: true
-                },
-                {
-                    label: "Revenue",
-                    data: [99, 135, 170, 130, 190, 180, 270],
-                    backgroundColor: "rgba(0, 156, 255, .3)",
-                    fill: true
-                }
-            ]
-            },
-        options: {
-            responsive: true
-        }
-    });
-    
-
-
-    // Single Line Chart
-    var ctx3 = $("#line-chart").get(0).getContext("2d");
-    var myChart3 = new Chart(ctx3, {
-        type: "line",
-        data: {
-            labels: [50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150],
-            datasets: [{
-                label: "Salse",
-                fill: false,
-                backgroundColor: "rgba(0, 156, 255, .3)",
-                data: [7, 8, 8, 9, 9, 9, 10, 11, 14, 14, 15]
-            }]
-        },
-        options: {
-            responsive: true
-        }
-    });
-
-
-    // Single Bar Chart
-    var ctx4 = $("#bar-chart").get(0).getContext("2d");
-    var myChart4 = new Chart(ctx4, {
-        type: "bar",
-        data: {
-            labels: ["Italy", "France", "Spain", "USA", "Argentina"],
-            datasets: [{
-                backgroundColor: [
-                    "rgba(0, 156, 255, .7)",
-                    "rgba(0, 156, 255, .6)",
-                    "rgba(0, 156, 255, .5)",
-                    "rgba(0, 156, 255, .4)",
-                    "rgba(0, 156, 255, .3)"
-                ],
-                data: [55, 49, 44, 24, 15]
-            }]
-        },
-        options: {
-            responsive: true
-        }
-    });
-
-
-    // Pie Chart
-    var ctx5 = $("#pie-chart").get(0).getContext("2d");
-    var myChart5 = new Chart(ctx5, {
-        type: "pie",
-        data: {
-            labels: ["Italy", "France", "Spain", "USA", "Argentina"],
-            datasets: [{
-                backgroundColor: [
-                    "rgba(0, 156, 255, .7)",
-                    "rgba(0, 156, 255, .6)",
-                    "rgba(0, 156, 255, .5)",
-                    "rgba(0, 156, 255, .4)",
-                    "rgba(0, 156, 255, .3)"
-                ],
-                data: [55, 49, 44, 24, 15]
-            }]
-        },
-        options: {
-            responsive: true
-        }
-    });
-
-
-    // Doughnut Chart
-    var ctx6 = $("#doughnut-chart").get(0).getContext("2d");
-    var myChart6 = new Chart(ctx6, {
-        type: "doughnut",
-        data: {
-            labels: ["Italy", "France", "Spain", "USA", "Argentina"],
-            datasets: [{
-                backgroundColor: [
-                    "rgba(0, 156, 255, .7)",
-                    "rgba(0, 156, 255, .6)",
-                    "rgba(0, 156, 255, .5)",
-                    "rgba(0, 156, 255, .4)",
-                    "rgba(0, 156, 255, .3)"
-                ],
-                data: [55, 49, 44, 24, 15]
-            }]
-        },
-        options: {
-            responsive: true
-        }
-    });
-
-    
+//
+//     // Worldwide Sales Chart
+//     var ctx1 = $("#worldwide-sales").get(0).getContext("2d");
+//     var myChart1 = new Chart(ctx1, {
+//         type: "bar",
+//         data: {
+//             labels: ["2016", "2017", "2018", "2019", "2020", "2021", "2022"],
+//             datasets: [{
+//                     label: "USA",
+//                     data: [15, 30, 55, 65, 60, 80, 95],
+//                     backgroundColor: "rgba(0, 156, 255, .7)"
+//                 },
+//                 {
+//                     label: "UK",
+//                     data: [8, 35, 40, 60, 70, 55, 75],
+//                     backgroundColor: "rgba(0, 156, 255, .5)"
+//                 },
+//                 {
+//                     label: "AU",
+//                     data: [12, 25, 45, 55, 65, 70, 60],
+//                     backgroundColor: "rgba(0, 156, 255, .3)"
+//                 }
+//             ]
+//             },
+//         options: {
+//             responsive: true
+//         }
+//     });
+//
+//
+//     // Salse & Revenue Chart
+//     var ctx2 = $("#salse-revenue").get(0).getContext("2d");
+//     var myChart2 = new Chart(ctx2, {
+//         type: "line",
+//         data: {
+//             labels: ["2016", "2017", "2018", "2019", "2020", "2021", "2022"],
+//             datasets: [{
+//                     label: "Salse",
+//                     data: [15, 30, 55, 45, 70, 65, 85],
+//                     backgroundColor: "rgba(0, 156, 255, .5)",
+//                     fill: true
+//                 },
+//                 {
+//                     label: "Revenue",
+//                     data: [99, 135, 170, 130, 190, 180, 270],
+//                     backgroundColor: "rgba(0, 156, 255, .3)",
+//                     fill: true
+//                 }
+//             ]
+//             },
+//         options: {
+//             responsive: true
+//         }
+//     });
+//
+//
+//
+//     // Single Line Chart
+//     var ctx3 = $("#line-chart").get(0).getContext("2d");
+//     var myChart3 = new Chart(ctx3, {
+//         type: "line",
+//         data: {
+//             labels: [50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150],
+//             datasets: [{
+//                 label: "Salse",
+//                 fill: false,
+//                 backgroundColor: "rgba(0, 156, 255, .3)",
+//                 data: [7, 8, 8, 9, 9, 9, 10, 11, 14, 14, 15]
+//             }]
+//         },
+//         options: {
+//             responsive: true
+//         }
+//     });
+//
+//
+//     // Single Bar Chart
+//     var ctx4 = $("#bar-chart").get(0).getContext("2d");
+//     var myChart4 = new Chart(ctx4, {
+//         type: "bar",
+//         data: {
+//             labels: ["Italy", "France", "Spain", "USA", "Argentina"],
+//             datasets: [{
+//                 backgroundColor: [
+//                     "rgba(0, 156, 255, .7)",
+//                     "rgba(0, 156, 255, .6)",
+//                     "rgba(0, 156, 255, .5)",
+//                     "rgba(0, 156, 255, .4)",
+//                     "rgba(0, 156, 255, .3)"
+//                 ],
+//                 data: [55, 49, 44, 24, 15]
+//             }]
+//         },
+//         options: {
+//             responsive: true
+//         }
+//     });
+//
+//
+//     // Pie Chart
+//     var ctx5 = $("#pie-chart").get(0).getContext("2d");
+//     var myChart5 = new Chart(ctx5, {
+//         type: "pie",
+//         data: {
+//             labels: ["Italy", "France", "Spain", "USA", "Argentina"],
+//             datasets: [{
+//                 backgroundColor: [
+//                     "rgba(0, 156, 255, .7)",
+//                     "rgba(0, 156, 255, .6)",
+//                     "rgba(0, 156, 255, .5)",
+//                     "rgba(0, 156, 255, .4)",
+//                     "rgba(0, 156, 255, .3)"
+//                 ],
+//                 data: [55, 49, 44, 24, 15]
+//             }]
+//         },
+//         options: {
+//             responsive: true
+//         }
+//     });
+//
+//
+//     // Doughnut Chart
+//     var ctx6 = $("#doughnut-chart").get(0).getContext("2d");
+//     var myChart6 = new Chart(ctx6, {
+//         type: "doughnut",
+//         data: {
+//             labels: ["Italy", "France", "Spain", "USA", "Argentina"],
+//             datasets: [{
+//                 backgroundColor: [
+//                     "rgba(0, 156, 255, .7)",
+//                     "rgba(0, 156, 255, .6)",
+//                     "rgba(0, 156, 255, .5)",
+//                     "rgba(0, 156, 255, .4)",
+//                     "rgba(0, 156, 255, .3)"
+//                 ],
+//                 data: [55, 49, 44, 24, 15]
+//             }]
+//         },
+//         options: {
+//             responsive: true
+//         }
+//     });
+//
+//
 })(jQuery);
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -6,278 +6,237 @@
 
 <head>
     <title>Home</title>
+
+    <!-- JQUERY LIBRARY -->
+    <script src="/webjars/jquery/3.5.1/jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+    <style>
+        .review-content {
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 1;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: normal;
+            line-height: 1.5; /* 줄 간격 조절 */
+            max-height: 3em; /* 2줄의 높이를 설정 (line-height * 2) */
+        }
+
+        .review-count {
+            font-size: small;
+        }
+    </style>
 </head>
 
 <body>
 <div layout:fragment="content">
-    <!-- Sale & Revenue Start -->
     <div class="container-fluid pt-4 px-4">
-        <div class="row g-4">
-            <div class="col-sm-6 col-xl-3">
-                <div class="bg-light rounded d-flex align-items-center justify-content-between p-4">
-                    <i class="fa fa-chart-line fa-3x text-primary"></i>
-                    <div class="ms-3">
-                        <p class="mb-2">Today Sale</p>
-                        <h6 class="mb-0">$1234</h6>
+
+        <!-- mall review Chart Start -->
+        <div class="col-sm-12 col-xl-12 m-2">
+            <div class="bg-light rounded h-100 p-4">
+                <h6 class="mb-4">쇼핑몰 전체 리뷰</h6>
+                <canvas id="reviewCountChart"></canvas>
+            </div>
+        </div>
+
+        <script>
+            $(document).ready(function () {
+                // Ajax request to fetch data
+                $.ajax({
+                    url: '/chart/mall/review-count', // 실제 데이터를 가져올 URL로 수정해야 합니다.
+                    type: 'GET',
+                    dataType: 'json',
+                    success: function (data) {
+                        // 데이터 배열 초기화
+                        var labels = [];
+                        var totalReviewCount = [];
+                        var positiveReviewCount = [];
+                        var negativeReviewCount = [];
+                        var neutralReviewCount = [];
+
+                        // 데이터를 추출하여 배열에 저장
+                        for (var i = 0; i < data.length; i++) {
+                            console.log(data[i].reviewYear + '-' + data[i].reviewMonth + ' : ' + data[i].reviewCount);
+                            labels.push(data[i].reviewYear + '-' + data[i].reviewMonth);
+                            totalReviewCount.push(data[i].reviewCount);
+                            positiveReviewCount.push(data[i].positiveReviewCount);
+                            negativeReviewCount.push(data[i].negativeReviewCount);
+                            neutralReviewCount.push(data[i].neutralReviewCount);
+                        }
+
+                        // 차트 생성
+                        var ctx = document.getElementById('reviewCountChart').getContext('2d');
+                        var myChart = new Chart(ctx, {
+                            type: 'line',
+                            data: {
+                                labels: labels,
+                                datasets: [
+                                    {
+                                        label: "Positive",
+                                        data: positiveReviewCount,
+                                        backgroundColor: "rgba(0, 156, 255, .5)",
+                                        borderColor: "rgba(0, 156, 255, .5)",
+                                        borderWidth: 2,
+                                        // fill: true
+                                    },
+                                    {
+                                        label: "Negative",
+                                        data: negativeReviewCount,
+                                        backgroundColor: "rgba(255, 0, 0, .5)",
+                                        borderColor: "rgba(255, 0, 0, .5)",
+                                        borderWidth: 2,
+                                        // fill: true
+                                    },
+                                    {
+                                        label: "Neutral",
+                                        data: neutralReviewCount,
+                                        backgroundColor: "rgba(255, 255, 0, .5)",
+                                        borderColor: "rgba(255, 255, 0, .5)",
+                                        borderWidth: 2,
+                                        // fill: true
+                                    },
+                                    {
+                                        label: 'Total',
+                                        data: totalReviewCount,
+                                        backgroundColor: "rgba(0, 255, 0, .5)",
+                                        borderColor: "rgba(0, 255, 0, .5)",
+                                        borderWidth: 2,
+                                        // fill: true
+                                    }
+                                ]
+                            }
+                        });
+                    },
+                    error: function (xhr, status, error) {
+                        // Log any errors to the console
+                        console.error('Error fetching data:', error);
+                    }
+                });
+            });
+        </script>
+
+
+        <!-- Widgets Start -->
+        <div class="container-fluid pt-4 px-4">
+            <div class="row g-4">
+                <div class="col-sm-12 col-md-6 col-xl-4">
+                    <div class="h-100 bg-light rounded p-4">
+                        <div class="d-flex align-items-center justify-content-between mb-2">
+                            <h6 class="mb-0">Recent</h6>
+                        </div>
+                        <!-- Ajax로 내용이 로드됩니다 -->
+                        <div id="recent-review-container"></div>
                     </div>
                 </div>
-            </div>
-            <div class="col-sm-6 col-xl-3">
-                <div class="bg-light rounded d-flex align-items-center justify-content-between p-4">
-                    <i class="fa fa-chart-bar fa-3x text-primary"></i>
-                    <div class="ms-3">
-                        <p class="mb-2">Total Sale</p>
-                        <h6 class="mb-0">$1234</h6>
+
+                <div class="col-sm-12 col-md-6 col-xl-4">
+                    <div class="h-100 bg-light rounded p-4">
+                        <div class="d-flex align-items-center justify-content-between mb-2">
+                            <h6 class="mb-0">Popular User</h6>
+                        </div>
+                        <div id="popular-user-container"></div>
                     </div>
                 </div>
-            </div>
-            <div class="col-sm-6 col-xl-3">
-                <div class="bg-light rounded d-flex align-items-center justify-content-between p-4">
-                    <i class="fa fa-chart-area fa-3x text-primary"></i>
-                    <div class="ms-3">
-                        <p class="mb-2">Today Revenue</p>
-                        <h6 class="mb-0">$1234</h6>
-                    </div>
-                </div>
-            </div>
-            <div class="col-sm-6 col-xl-3">
-                <div class="bg-light rounded d-flex align-items-center justify-content-between p-4">
-                    <i class="fa fa-chart-pie fa-3x text-primary"></i>
-                    <div class="ms-3">
-                        <p class="mb-2">Total Revenue</p>
-                        <h6 class="mb-0">$1234</h6>
+                <div class="col-sm-12 col-md-6 col-xl-4">
+                    <div class="h-100 bg-light rounded p-4">
+                        <div class="d-flex align-items-center justify-content-between mb-4">
+                            <h6 class="mb-0">Popular Store</h6>
+                        </div>
+                        <div id="popular-store-container"></div>
                     </div>
                 </div>
             </div>
         </div>
+
+        <script th:inline="javascript">
+            $(document).ready(function () {
+                $.ajax({
+                    url: '/review/user/recent',
+                    method: 'GET',
+                    success: function (data) {
+                        data.forEach(function (review) {
+                            $('#recent-review-container').append(`
+                        <div class="d-flex align-items-center pt-3">
+                            <img class="rounded-circle flex-shrink-0" src="${review.userImagePath}" alt="User Profile" style="width: 40px; height: 40px;">
+                            <div class="w-100 ms-3">
+                                <div class="d-flex w-100 justify-content-between">
+                                    <h6 class="mb-0">${review.userName}</h6>
+                                    <small>팔로워 : ${review.followerCount}</small>
+                                    <small>팔로잉 : ${review.followingCount}</small>
+                                </div>
+                                <span class="review-content">${review.contents}</span>
+                            </div>
+                        </div>
+                    `);
+                        });
+                    },
+                    error: function (error) {
+                        console.error("사용자 프로필을 가져오는 중 오류가 발생했습니다!", error);
+                    }
+                });
+            });
+
+            $(document).ready(function () {
+                $.ajax({
+                    url: '/follow/user/popular',
+                    method: 'GET',
+                    success: function (data) {
+                        data.forEach(function (data) {
+                            $('#popular-user-container').append(`
+                        <div class="d-flex align-items-center pt-3">
+                            <img class="rounded-circle flex-shrink-0" src="${data.imagePath}" alt="User Profile" style="width: 40px; height: 40px;">
+                            <div class="w-100 ms-3">
+                                <div class="d-flex w-100 justify-content-between">
+                                    <h6 class="mb-0">${data.userName}</h6>
+                                    <small>팔로워 : ${data.followerCount}</small>
+                                    <small>팔로잉 : ${data.followingCount}</small>
+                                </div>
+                                <span class="review-content">작성한 리뷰 수 : ${data.reviewCount}</span>
+                            </div>
+                        </div>
+                    `);
+                        });
+                    },
+                    error: function (error) {
+                        console.error("사용자 프로필을 가져오는 중 오류가 발생했습니다!", error);
+                    }
+                });
+            });
+
+            $(document).ready(function () {
+                $.ajax({
+                    url: '/review/store/popular',
+                    method: 'GET',
+                    success: function (data) {
+                        data.forEach(function (data) {
+                            $('#popular-store-container').append(`
+                        <div class="d-flex align-items-center pt-3">
+                            <img class="flex-shrink-0" src="${data.storeImage}" alt="User Profile" style="width: 40px; height: 40px;">
+                            <div class="w-100 ms-3">
+                                <div class="w-100">
+                                    <h6 class="mb-0">${data.storeName}</h6>
+                                    <small>${data.mallName} ${data.floor}층</small>
+                                </div>
+                                <div class="d-flex w-100 justify-content-start">
+                                <span class="review-count">total : ${data.reviewCount}</span>
+                                <span class="review-count mx-3">positive : ${data.positiveReviewCount}</span>
+<!--                                <span class="review-count">negative : ${data.negativeReviewCount}</span>-->
+                                </div>
+                            </div>
+                        </div>
+                    `);
+                        });
+                    },
+                    error: function (error) {
+                        console.error("사용자 프로필을 가져오는 중 오류가 발생했습니다!", error);
+                    }
+                });
+            });
+        </script>
+        <!-- Widgets End -->
     </div>
-    <!-- Sale & Revenue End -->
-
-
-    <!-- Sales Chart Start -->
-    <div class="container-fluid pt-4 px-4">
-        <div class="row g-4">
-            <div class="col-sm-12 col-xl-6">
-                <div class="bg-light text-center rounded p-4">
-                    <div class="d-flex align-items-center justify-content-between mb-4">
-                        <h6 class="mb-0">Worldwide Sales</h6>
-                        <a href="">Show All</a>
-                    </div>
-                    <canvas id="worldwide-sales"></canvas>
-                </div>
-            </div>
-            <div class="col-sm-12 col-xl-6">
-                <div class="bg-light text-center rounded p-4">
-                    <div class="d-flex align-items-center justify-content-between mb-4">
-                        <h6 class="mb-0">Salse & Revenue</h6>
-                        <a href="">Show All</a>
-                    </div>
-                    <canvas id="salse-revenue"></canvas>
-                </div>
-            </div>
-        </div>
-    </div>
-    <!-- Sales Chart End -->
-
-
-    <!-- Recent Sales Start -->
-    <div class="container-fluid pt-4 px-4">
-        <div class="bg-light text-center rounded p-4">
-            <div class="d-flex align-items-center justify-content-between mb-4">
-                <h6 class="mb-0">Recent Salse</h6>
-                <a href="">Show All</a>
-            </div>
-            <div class="table-responsive">
-                <table class="table text-start align-middle table-bordered table-hover mb-0">
-                    <thead>
-                    <tr class="text-dark">
-                        <th scope="col"><input class="form-check-input" type="checkbox"></th>
-                        <th scope="col">Date</th>
-                        <th scope="col">Invoice</th>
-                        <th scope="col">Customer</th>
-                        <th scope="col">Amount</th>
-                        <th scope="col">Status</th>
-                        <th scope="col">Action</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr>
-                        <td><input class="form-check-input" type="checkbox"></td>
-                        <td>01 Jan 2045</td>
-                        <td>INV-0123</td>
-                        <td>Jhon Doe</td>
-                        <td>$123</td>
-                        <td>Paid</td>
-                        <td><a class="btn btn-sm btn-primary" href="">Detail</a></td>
-                    </tr>
-                    <tr>
-                        <td><input class="form-check-input" type="checkbox"></td>
-                        <td>01 Jan 2045</td>
-                        <td>INV-0123</td>
-                        <td>Jhon Doe</td>
-                        <td>$123</td>
-                        <td>Paid</td>
-                        <td><a class="btn btn-sm btn-primary" href="">Detail</a></td>
-                    </tr>
-                    <tr>
-                        <td><input class="form-check-input" type="checkbox"></td>
-                        <td>01 Jan 2045</td>
-                        <td>INV-0123</td>
-                        <td>Jhon Doe</td>
-                        <td>$123</td>
-                        <td>Paid</td>
-                        <td><a class="btn btn-sm btn-primary" href="">Detail</a></td>
-                    </tr>
-                    <tr>
-                        <td><input class="form-check-input" type="checkbox"></td>
-                        <td>01 Jan 2045</td>
-                        <td>INV-0123</td>
-                        <td>Jhon Doe</td>
-                        <td>$123</td>
-                        <td>Paid</td>
-                        <td><a class="btn btn-sm btn-primary" href="">Detail</a></td>
-                    </tr>
-                    <tr>
-                        <td><input class="form-check-input" type="checkbox"></td>
-                        <td>01 Jan 2045</td>
-                        <td>INV-0123</td>
-                        <td>Jhon Doe</td>
-                        <td>$123</td>
-                        <td>Paid</td>
-                        <td><a class="btn btn-sm btn-primary" href="">Detail</a></td>
-                    </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
-    <!-- Recent Sales End -->
-
-
-    <!-- Widgets Start -->
-    <div class="container-fluid pt-4 px-4">
-        <div class="row g-4">
-            <div class="col-sm-12 col-md-6 col-xl-4">
-                <div class="h-100 bg-light rounded p-4">
-                    <div class="d-flex align-items-center justify-content-between mb-2">
-                        <h6 class="mb-0">Messages</h6>
-                        <a href="">Show All</a>
-                    </div>
-                    <div class="d-flex align-items-center border-bottom py-3">
-                        <img class="rounded-circle flex-shrink-0" src="/img/user.jpg" alt=""
-                             style="width: 40px; height: 40px;">
-                        <div class="w-100 ms-3">
-                            <div class="d-flex w-100 justify-content-between">
-                                <h6 class="mb-0">Jhon Doe</h6>
-                                <small>15 minutes ago</small>
-                            </div>
-                            <span>Short message goes here...</span>
-                        </div>
-                    </div>
-                    <div class="d-flex align-items-center border-bottom py-3">
-                        <img class="rounded-circle flex-shrink-0" src="/img/user.jpg" alt=""
-                             style="width: 40px; height: 40px;">
-                        <div class="w-100 ms-3">
-                            <div class="d-flex w-100 justify-content-between">
-                                <h6 class="mb-0">Jhon Doe</h6>
-                                <small>15 minutes ago</small>
-                            </div>
-                            <span>Short message goes here...</span>
-                        </div>
-                    </div>
-                    <div class="d-flex align-items-center border-bottom py-3">
-                        <img class="rounded-circle flex-shrink-0" src="/img/user.jpg" alt=""
-                             style="width: 40px; height: 40px;">
-                        <div class="w-100 ms-3">
-                            <div class="d-flex w-100 justify-content-between">
-                                <h6 class="mb-0">Jhon Doe</h6>
-                                <small>15 minutes ago</small>
-                            </div>
-                            <span>Short message goes here...</span>
-                        </div>
-                    </div>
-                    <div class="d-flex align-items-center pt-3">
-                        <img class="rounded-circle flex-shrink-0" src="/img/user.jpg" alt=""
-                             style="width: 40px; height: 40px;">
-                        <div class="w-100 ms-3">
-                            <div class="d-flex w-100 justify-content-between">
-                                <h6 class="mb-0">Jhon Doe</h6>
-                                <small>15 minutes ago</small>
-                            </div>
-                            <span>Short message goes here...</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="col-sm-12 col-md-6 col-xl-4">
-                <div class="h-100 bg-light rounded p-4">
-                    <div class="d-flex align-items-center justify-content-between mb-4">
-                        <h6 class="mb-0">Calender</h6>
-                        <a href="">Show All</a>
-                    </div>
-                    <div id="calender"></div>
-                </div>
-            </div>
-            <div class="col-sm-12 col-md-6 col-xl-4">
-                <div class="h-100 bg-light rounded p-4">
-                    <div class="d-flex align-items-center justify-content-between mb-4">
-                        <h6 class="mb-0">To Do List</h6>
-                        <a href="">Show All</a>
-                    </div>
-                    <div class="d-flex mb-2">
-                        <input class="form-control bg-transparent" type="text" placeholder="Enter task">
-                        <button type="button" class="btn btn-primary ms-2">Add</button>
-                    </div>
-                    <div class="d-flex align-items-center border-bottom py-2">
-                        <input class="form-check-input m-0" type="checkbox">
-                        <div class="w-100 ms-3">
-                            <div class="d-flex w-100 align-items-center justify-content-between">
-                                <span>Short task goes here...</span>
-                                <button class="btn btn-sm"><i class="fa fa-times"></i></button>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="d-flex align-items-center border-bottom py-2">
-                        <input class="form-check-input m-0" type="checkbox">
-                        <div class="w-100 ms-3">
-                            <div class="d-flex w-100 align-items-center justify-content-between">
-                                <span>Short task goes here...</span>
-                                <button class="btn btn-sm"><i class="fa fa-times"></i></button>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="d-flex align-items-center border-bottom py-2">
-                        <input class="form-check-input m-0" type="checkbox" checked>
-                        <div class="w-100 ms-3">
-                            <div class="d-flex w-100 align-items-center justify-content-between">
-                                <span><del>Short task goes here...</del></span>
-                                <button class="btn btn-sm text-primary"><i class="fa fa-times"></i></button>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="d-flex align-items-center border-bottom py-2">
-                        <input class="form-check-input m-0" type="checkbox">
-                        <div class="w-100 ms-3">
-                            <div class="d-flex w-100 align-items-center justify-content-between">
-                                <span>Short task goes here...</span>
-                                <button class="btn btn-sm"><i class="fa fa-times"></i></button>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="d-flex align-items-center pt-2">
-                        <input class="form-check-input m-0" type="checkbox">
-                        <div class="w-100 ms-3">
-                            <div class="d-flex w-100 align-items-center justify-content-between">
-                                <span>Short task goes here...</span>
-                                <button class="btn btn-sm"><i class="fa fa-times"></i></button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <!-- Widgets End -->
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -52,7 +52,7 @@
             </a>
             <div class="d-flex align-items-center ms-4 mb-4">
                 <div class="position-relative">
-                    <img class="rounded-circle" src="img/user.jpg" alt="" style="width: 40px; height: 40px;">
+                    <img class="rounded-circle" src="/img/user.jpg" alt="" style="width: 40px; height: 40px;">
                     <div class="bg-success rounded-circle border border-2 border-white position-absolute end-0 bottom-0 p-1"></div>
                 </div>
                 <div class="ms-3">
@@ -111,7 +111,7 @@
                     <div class="dropdown-menu dropdown-menu-end bg-light border-0 rounded-0 rounded-bottom m-0">
                         <a href="#" class="dropdown-item">
                             <div class="d-flex align-items-center">
-                                <img class="rounded-circle" src="img/user.jpg" alt="" style="width: 40px; height: 40px;">
+                                <img class="rounded-circle" src="/img/user.jpg" alt="" style="width: 40px; height: 40px;">
                                 <div class="ms-2">
                                     <h6 class="fw-normal mb-0">Jhon send you a message</h6>
                                     <small>15 minutes ago</small>
@@ -121,7 +121,7 @@
                         <hr class="dropdown-divider">
                         <a href="#" class="dropdown-item">
                             <div class="d-flex align-items-center">
-                                <img class="rounded-circle" src="img/user.jpg" alt="" style="width: 40px; height: 40px;">
+                                <img class="rounded-circle" src="/img/user.jpg" alt="" style="width: 40px; height: 40px;">
                                 <div class="ms-2">
                                     <h6 class="fw-normal mb-0">Jhon send you a message</h6>
                                     <small>15 minutes ago</small>
@@ -131,7 +131,7 @@
                         <hr class="dropdown-divider">
                         <a href="#" class="dropdown-item">
                             <div class="d-flex align-items-center">
-                                <img class="rounded-circle" src="img/user.jpg" alt="" style="width: 40px; height: 40px;">
+                                <img class="rounded-circle" src="/img/user.jpg" alt="" style="width: 40px; height: 40px;">
                                 <div class="ms-2">
                                     <h6 class="fw-normal mb-0">Jhon send you a message</h6>
                                     <small>15 minutes ago</small>
@@ -168,7 +168,7 @@
                 </div>
                 <div class="nav-item dropdown">
                     <a href="#" class="nav-link dropdown-toggle" data-bs-toggle="dropdown">
-                        <img class="rounded-circle me-lg-2" src="img/user.jpg" alt="" style="width: 40px; height: 40px;">
+                        <img class="rounded-circle me-lg-2" src="/img/user.jpg" alt="" style="width: 40px; height: 40px;">
                         <span class="d-none d-lg-inline-flex">John Doe</span>
                     </a>
                     <div class="dropdown-menu dropdown-menu-end bg-light border-0 rounded-0 rounded-bottom m-0">
@@ -214,8 +214,10 @@
 </div>
 
 <!-- JavaScript Libraries -->
-<script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>
+<!--<script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>-->
+<script src="/webjars/jquery/3.5.1/jquery.min.js"></script>
+<!--<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js"></script>-->
+<script src="/webjars/bootstrap/5.0.0/js/bootstrap.bundle.min.js"></script>
 <script src="/lib/chart/chart.min.js"></script>
 <script src="/lib/easing/easing.min.js"></script>
 <script src="/lib/waypoints/waypoints.min.js"></script>

--- a/src/main/resources/templates/review/reviewDetail.html
+++ b/src/main/resources/templates/review/reviewDetail.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.w3.org/1999/xhtml"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{/layout/layout}">
+
+<head>
+    <title>Store-List</title>
+
+    <!-- JQUERY LIBRARY -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+
+    <style>
+        .review-container {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(600px, 1fr)); /* 최소 너비를 350px로 조정 */
+            gap: 1.5rem; /* 간격을 조금 더 넓게 조정 */
+        }
+
+        .review-item {
+            border: 1px solid #e9ecef;
+            border-radius: 10px;
+            padding: 1.5rem; /* 패딩을 늘려서 카드 내부 여백을 더 넓게 */
+            background-color: #e3e5e8;
+        }
+
+        .image-container {
+            background-color: #f5f8f8;
+            position: relative;
+            width: 100%;
+            height: 400px; /* 이미지 컨테이너 높이를 350px로 증가 */
+            overflow: hidden;
+        }
+
+        .review-image {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            max-width: 100%;
+            max-height: 100%;
+            transform: translate(-50%, -50%);
+            object-fit: cover; /* 이미지가 컨테이너를 꽉 채우도록 설정 */
+        }
+
+        .review-content {
+            display: -webkit-box;
+            -webkit-line-clamp: 2; /* 두 줄까지 표시 */
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-height: 4em; /* 두 줄의 대략적인 높이 */
+        }
+
+        .sentiment-container {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+
+            border: 1px solid #c2c7cc;
+        }
+
+        .feedback-container {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+            border: 1px solid #c2c7cc;
+        }
+
+        .feedback-list {
+            min-height: 120px; /* 피드백 리스트의 최소 높이를 증가 */
+            line-height: 20px; /* 예시 줄 높이 */
+        }
+
+        .store-container {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 0.5rem;
+            border: 1px solid #c2c7cc;
+            background-color: #edf5f5;
+        }
+
+        .store-info {
+            display: flex;
+            justify-content: left;
+            gap: 0.5rem;
+        }
+
+        .shop-name {
+            text-align: left;
+        }
+
+        .mall-name {
+            font-size: 0.8rem;
+        }
+
+    </style>
+</head>
+
+<body>
+<div layout:fragment="content">
+
+    <div class="container-fluid pt-4 px-4">
+        <div class="bg-light text-center rounded p-4">
+            <!-- 리스트 출력 -->
+            <div class="review-container">
+                <div class="review-item">
+                    <!-- 유저 정보(프로필 이미지, 이름, 날짜(현재 기준 - 작성날짜)) -->
+                    <div class="d-flex align-items-center justify-content-between">
+                        <div th:onclick="|location.href='@{/user/detail/}' + ${review.userId()}|">
+                            <img th:src="${review.userImagePath()}" alt="profile image"
+                                 class="rounded-circle m-2" style="width: 3rem; height: 3rem">
+                            <span th:text="${review.userName()}" class="fs-4">User Name</span>
+                        </div>
+                        <div class="mx-2 text-secondary">
+                            <spna th:text="${#temporals.format(review.createdAt(), 'yyyy-MM-dd hh시dd분ss초')}"
+                                  class="fs-6">Review Created At
+                            </spna>
+                        </div>
+                    </div>
+                    <!-- 리뷰 이미지 -->
+                    <div>
+                        <!-- (캐러셀) 이미지 슬라이드 -->
+                        <div th:id="'carouselExampleControlsNoTouching-' + ${review.reviewId()}"
+                             class="carousel slide"
+                             data-bs-touch="false" data-bs-interval="false">
+                            <div class="carousel-inner">
+                                <div class="image-container carousel-item text-center"
+                                     th:each="image, iterStat : ${review.reviewImagePaths()}"
+                                     th:classappend="${iterStat.first} ? 'active'">
+                                    <img th:src="${image}" class="d-block mx-auto review-image" alt="...">
+                                </div>
+                            </div>
+
+                            <button class="carousel-control-prev" type="button"
+                                    th:data-bs-target="'#carouselExampleControlsNoTouching-' + ${review.reviewId()}"
+                                    data-bs-slide="prev">
+                                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                                <span class="visually-hidden">Previous</span>
+                            </button>
+                            <button class="carousel-control-next" type="button"
+                                    th:data-bs-target="'#carouselExampleControlsNoTouching-' + ${review.reviewId()}"
+                                    data-bs-slide="next">
+                                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                                <span class="visually-hidden">Next</span>
+                            </button>
+                        </div>
+
+                        <!-- 이미지가 없는 경우 No Review Image 표시 -->
+                        <div class="image-container text-center d-flex justify-content-center align-items-center"
+                             th:if="${review.reviewImagePaths().size() == 0}">
+                            <h2>No Review Image</h2>
+                        </div>
+                    </div>
+                    <!-- 리뷰 좋아요  -->
+                    <div class="mx-2 my-1">
+                        <div class="text-start">좋아요 <span th:text="${review.likeCount}">0</span>개</div>
+                    </div>
+
+
+                    <!-- 리뷰 내용 -->
+                    <div class="text-start m-2 text-dark">
+                        <span class="fw-bold me-2" th:text="${review.userName()}"></span>
+                        <span class="review-content" th:text="${review.contents()}">Review Content</span>
+                    </div>
+
+                    <div class="m-2 sentiment-container">
+                        <!-- 리뷰 요약 -->
+                        <div class="text-start m-2 text-dark d-flex">
+                            <span class="mx-2">리뷰 요약 : </span>
+                            <span class="review-content" th:text="${review.summary()}">Review Summary</span>
+                        </div>
+                    </div>
+
+                    <!-- 리뷰 피드백 -->
+                    <div class="m-2 text-start feedback-container">
+                        <span class="fw-bold align-self-center"> -- 피드백 --</span>
+                        <div class="feedback-list">
+                            <div th:if="${review.reviewFeedbackSelection().size() != 0}">
+                                <ul>
+                                    <li th:each="feedback : ${review.reviewFeedbackSelection()}">
+                                        <span th:text="${feedback}">Feedback</span>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="text-center d-flex align-items-center"
+                                 th:if="${review.reviewFeedbackSelection().size() == 0}">
+                                <h4>No Review Feedback</h4>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="store-container m-2" th:onclick="|location.href='@{/store/detail/}' + ${review.storeId()}|">
+                        <div class="store-info">
+                            <img th:src="${review.storeImagePath()}" alt="store image"
+                                 style="width: 3.5rem; height: 3.5rem">
+                            <div class="shop-name mx-2">
+                                <div class="fw-bolder fs-5" th:text="${review.storeName()}"></div>
+                                <div class="fw-light mall-name" th:text="${review.mallName()}"></div>
+                            </div>
+                        </div>
+                        <div>
+                            <a class="fw-bolder fs-4 text-black-50 m-3"> > </a>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/review/reviewList.html
+++ b/src/main/resources/templates/review/reviewList.html
@@ -5,11 +5,10 @@
       layout:decorate="~{/layout/layout}">
 
 <head>
-    <title>Store-List</title>
+    <title>Review-List</title>
 
     <!-- JQUERY LIBRARY -->
-<!--    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>-->
-    <script src="/webjars/jquery/3.5.1/jquery.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <style>
         .form-group{
             text-align: left;
@@ -57,7 +56,6 @@
                 type: 'GET',
                 dataType: 'text',
                 success: function(data) {
-                    console.log('Data:', data);
                     // 수신된 데이터로 결과 div 업데이트
                     $('#mallName').html('<h1>' + data + ' 매장 리스트</h1>');
                 },

--- a/src/main/resources/templates/store/storeDetail.html
+++ b/src/main/resources/templates/store/storeDetail.html
@@ -78,7 +78,7 @@
                             <label for="inputStoreFloor" class="col-sm-3 col-form-label">층수</label>
                             <div class="col-sm-9">
                                 <input type="text" class="form-control" id="inputStoreFloor"
-                                       th:value="${storeResponse.floor()}" readonly>
+                                       th:value="${storeResponse.floor().getFloor()} + 층" readonly>
                             </div>
                         </div>
                         <div class="row mb-3">

--- a/src/main/resources/templates/store/storeReviewList.html
+++ b/src/main/resources/templates/store/storeReviewList.html
@@ -111,7 +111,7 @@
                     <p>No reviews available.</p>
                 </div>
                 <div th:each="review, iterStat : ${reviewList}">
-                    <div class="review-item">
+                    <div class="review-item" th:onclick="|location.href='@{/review/detail/}' + ${review.reviewId()}|">
                         <!-- 유저 정보(프로필 이미지, 이름, 날짜(현재 기준 - 작성날짜)) -->
                         <div class="d-flex align-items-center">
                             <img th:src="${review.userImagePath()}" alt="profile image"

--- a/src/main/resources/templates/user/userList.html
+++ b/src/main/resources/templates/user/userList.html
@@ -60,7 +60,7 @@
                         <option value="">Select Sort Type</option>
                         <option
                                 th:each="sortType : ${T(com.ssg.starroadadmin.user.enums.UserSortType).values()}"
-                                th:value="${sortType}" th:text="${sortType}">
+                                th:value="${sortType}" th:text="${sortType.getDiscription()}">
                         </option>
                     </select>
                 </div>
@@ -85,16 +85,14 @@
                     </tr>
                     </thead>
                     <tbody>
-                    <tr th:each="user : ${userList}">
+                    <tr th:each="user : ${userList}" th:onclick="|location.href='@{/user/detail/}' + ${user.id()}|">
                         <td class="text-center col" th:text="${(pages.number) * 10 + userStat.count}">No</td>
                         <td class="text-center col-1">
                             <span th:text="${user.name()}">User Name</span>
                             <br/>
                             <span th:text="${user.nickname()}">User Nickname</span>
                         </td>
-                        <td class="text-center col-1">
-                            <a th:text="${user.email()}" th:href="@{'/user/' + ${user.id()}}">User Email</a>
-                        </td>
+                        <td class="text-center col-1" th:text="${user.email()}">User Email</td>
                         <td class="text-center col-1"><img th:src="${user.imagePath()}" alt="user profile image"
                                                            width="100" height="100"></td>
                         <td class="text-center col" th:text="${user.birth()}">User Birth</td>

--- a/src/main/resources/templates/user/userReviewList.html
+++ b/src/main/resources/templates/user/userReviewList.html
@@ -134,7 +134,7 @@
                     <p>No reviews available.</p>
                 </div>
                 <div th:each="review, iterStat : ${reviewList}">
-                    <div class="review-item">
+                    <div class="review-item" th:onclick="|location.href='@{/review/detail/}' + ${review.reviewId()}|">
                         <!-- 유저 정보(프로필 이미지, 이름, 날짜(현재 기준 - 작성날짜)) -->
                         <div class="d-flex align-items-center">
                             <img th:src="${review.userImagePath()}" alt="profile image"


### PR DESCRIPTION
## Kinds ✅
- [x] Feature
- [ ] Hotfix
- [ ] Bug Fix
- [ ] Infra

## Description ✏️ 
메인페이지
 - 현재 날짜 기준 12개월의 리뷰 감정들 차트로 출력
 - 최근 리뷰, 인기있는 리뷰어, 매장 5개 출력
 - 모든 데이터들을 ajax로 비동기로 받아옴

리뷰 페이지
 - 생략된 리뷰 내용 확인
 - 리뷰 요약 확인

리뷰 리스트 페이지
 - 인스타 형식으로 대략적인 리뷰 내용들 확인
 - 한 줄 넘어가면 ...으로 생략

전체적으로 
 - th:onclick 사용하여 클릭하면 넘어갈수 있도록 설정
 

## Changes 🛠️ 
### AS-IS
 - 대략적인 페이지들 구현

### TO-BE
 - 층 지도를 뛰워서 매장의 감정상태를 체크 할 수 있도록 변경

## Check List 📝 
### Template
- [x] index.html
- [x] reviewDetail.html
- [x] reviewList.html

## To Reviewers 🙏 
